### PR TITLE
fix oasis file

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -37,7 +37,6 @@ Test test
   Run$:               flag(tests)
   Command:            $test_runner
   WorkingDirectory:   lib_test
-  
 
 Executable bench1
   Path:               lib_test


### PR DESCRIPTION
seems like the trailing spaces are not accepted by the new oasis parser.
